### PR TITLE
PEP668 error: externally-managed-environment修正

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Pip install
-        run: pip install -r requirements.txt
+        run: pip install --break-system-packages -r requirements.txt
       - name: Parse JPX all stock list
         run: python parse_jpx_all_stock_list.py
       - name: Parse JPX new stock list


### PR DESCRIPTION
使い捨てのGithub Actions環境なので--break-system-packagesを許容する
