### PR TITLE
feat: 札幌証券取引所の上場銘柄スクレイピング機能を追加

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -28,6 +28,8 @@ jobs:
         run: python parse_kessan_list.py
       - name: Parse JPX new ETF list
         run: python parse_jpx_new_etf_list.py
+      - name: Parse SSE list
+        run: python parse_sse_list.py
       - name: Merge symbols
         run: python merge_symbols.py
       - name: Configure AWS Credentials for GitHub Actions

--- a/merge_symbols.py
+++ b/merge_symbols.py
@@ -47,6 +47,9 @@ with open("kessan.json", "r", encoding="utf-8") as json_file:
 with open("new_etf_listings.json", "r", encoding="utf-8") as json_file:
     new_etf_listings = json.load(json_file)
 
+with open("sse_listings.json", "r", encoding="utf-8") as json_file:
+    sse_listings = json.load(json_file)
+
 merged_all_stocks = {}
 
 for stock in monthly:
@@ -71,6 +74,12 @@ for stock in new_etf_listings:
     merged_all_stocks[str(stock["コード"])] = {
         "コード": str(stock["コード"]),
         "銘柄名": stock["銘柄名"],
+    }
+
+for stock in sse_listings:
+    merged_all_stocks[str(stock["証券コード"])] = {
+        "コード": str(stock["証券コード"]),
+        "銘柄名": stock["会社名"],
     }
 
 print(f"銘柄数: {len(merged_all_stocks)}")

--- a/parse_sse_list.py
+++ b/parse_sse_list.py
@@ -1,0 +1,44 @@
+# https://www.sse.or.jp/listing/listをスクレイピングして札幌証券取引所の上場銘柄一覧を取得する
+
+import requests
+from lxml import html
+import json
+
+url = "https://www.sse.or.jp/listing/list"
+response = requests.get(url)
+tree = html.fromstring(response.content)
+
+# 各銘柄のdt要素を取得（dtタグ内のaタグを取得）
+stock_items = tree.xpath("//dt/a")
+sse_stocks = []
+
+for link in stock_items:
+    # リンクテキストから証券コードと会社名を取得
+    link_text = link.text_content().strip()
+    # spanタグ内のコードを取得
+    code = link.xpath(".//span/text()")
+    if code:
+        code = code[0].strip()
+        # 会社名は全体のテキストからコードを除いた部分
+        name = link_text.replace(code, '').strip()
+        
+        # 株式会社を除去したバージョンも保持（他のパーサーと一貫性を保つため）
+        clean_name = name.replace('株式会社', '').replace('（株）', '')
+        
+        sse_stocks.append({
+            "証券コード": code,
+            "会社名": name,
+            "会社名（簡略）": clean_name,
+            "市場": "札証"
+        })
+
+# 件数チェック（1割以上減少したらエラー）
+# 札証の上場企業数は約60社前後
+EXPECTED_MIN_COUNT = 54  # 60の90%
+if len(sse_stocks) < EXPECTED_MIN_COUNT:
+    raise ValueError(f"札証上場データ件数が異常に少ないです。期待値: {EXPECTED_MIN_COUNT}件以上、実際: {len(sse_stocks)}件")
+
+print(f"札証上場銘柄数: {len(sse_stocks)}")
+
+with open("sse_listings.json", "w", encoding="utf-8") as json_file:
+    json_file.write(json.dumps(sse_stocks, ensure_ascii=False, indent=4))


### PR DESCRIPTION
## 概要
札幌証券取引所（札証）の上場銘柄リストをスクレイピングする機能を追加しました。

## 変更内容
- `parse_sse_list.py`: 札証Webサイト（https://www.sse.or.jp/listing/list）から上場銘柄情報を取得
- `merge_symbols.py`: 札証銘柄を既存のマージ処理に追加
- GitHub Actions: ワークフローに札証スクレイピングステップを追加

## 動作確認
- ✅ 札証64銘柄を正常に取得
- ✅ all_stocks.jsonへの統合を確認
- ✅ 銘柄コード1449（FUJIジャパン）などの札証単独上場銘柄が含まれることを確認

## テスト結果
```
$ python parse_sse_list.py
札証上場銘柄数: 64

$ python merge_symbols.py  
銘柄数: 4529
```

🤖 Generated with [Claude Code](https://claude.ai/code)